### PR TITLE
Bump version of target-duckdb

### DIFF
--- a/data_pipeline/meltano-plugins.yml
+++ b/data_pipeline/meltano-plugins.yml
@@ -26,4 +26,4 @@ plugins:
     - name: target-duckdb
       variant: jwills
       # TODO - remove the commit hash when JWills does a release
-      pip_url: git+https://github.com/jwills/target-duckdb.git@1b6b8575d0728b4c0b67378c0196b9524307ed87
+      pip_url: git+https://github.com/jwills/target-duckdb.git@36c8ce68a0b2584c4bbb07325482968b1edc0c40

--- a/data_pipeline/meltano_conf/loaders/loaders.yml
+++ b/data_pipeline/meltano_conf/loaders/loaders.yml
@@ -37,7 +37,7 @@ plugins:
   - name: target-duckdb
     variant: jwills
     # TODO - remove the commit hash when JWills does a release
-    pip_url: git+https://github.com/jwills/target-duckdb.git@1b6b8575d0728b4c0b67378c0196b9524307ed87
+    pip_url: git+https://github.com/jwills/target-duckdb.git@36c8ce68a0b2584c4bbb07325482968b1edc0c40
     config:
       path: md:${DB_NAME}
       token: ${MOTHERDUCK_TOKEN}

--- a/data_pipeline/plugins/loaders/target-duckdb--jwills.lock
+++ b/data_pipeline/plugins/loaders/target-duckdb--jwills.lock
@@ -6,7 +6,7 @@
   "label": "DuckDB",
   "docs": "https://hub.meltano.com/loaders/target-duckdb--jwills",
   "repo": "https://github.com/jwills/target-duckdb",
-  "pip_url": "target-duckdb~=0.6",
+  "pip_url": "target-duckdb~=0.8",
   "description": "DuckDB loader",
   "logo_url": "https://hub.meltano.com/assets/logos/loaders/duckdb.png",
   "settings_group_validation": [


### PR DESCRIPTION
bumps version of duckdb client, the old one is no longer supported by DuckDB/MotherDuck